### PR TITLE
Override yamllint config

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,44 @@
+rules:
+    braces:
+        min-spaces-inside: 1
+        max-spaces-inside: 1
+    brackets:
+        min-spaces-inside: 0
+        max-spaces-inside: 0
+    colons:
+        max-spaces-before: 0
+        max-spaces-after: 4
+    commas:
+        max-spaces-before: 0
+        min-spaces-after: 1
+        max-spaces-after: 1
+    comments:
+        level: error
+        require-starting-space: yes
+        min-spaces-from-content: 2
+    comments-indentation:
+        level: error
+    document-end:
+        level: error
+        present: no
+    document-start:
+        level: error
+        present: no
+    empty-lines:
+        max: 2
+        max-start: 0
+        max-end: 1
+    hyphens:
+        max-spaces-after: 1
+    indentation:
+        spaces: 4
+        indent-sequences: yes
+        check-multi-line-strings: yes
+    key-duplicates: enable
+    line-length:
+        max: 80
+        allow-non-breakable-words: yes
+    new-line-at-end-of-file: enable
+    new-lines:
+        type: unix
+    trailing-spaces: enable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ We are using [Style CI](https://styleci.io/)'s [Symfone template](https://stylec
 
 We are using [yamllint](https://github.com/adrienverge/yamllint) with the default configuration:
 
-    $ yamllint ./Controller/ ./DependencyInjection/ ./EventDispatcher/ ./Form/ ./Model/ ./Resources/ ./Strategy/ ./Tests/ .travis.yml .styleci.yml
+    $ yamllint ./Controller/ ./DependencyInjection/ ./EventDispatcher/ ./Form/ ./Model/ ./Resources/ ./Strategy/ ./Tests/ .travis.yml .styleci.yml .yamllint
 
 ### Twig and HTML
 


### PR DESCRIPTION
Fix #6.

Unfortunately, some options are not available in yamllint, I'll ask for them to be added, for thing like indentation. E.g. it's not possible to allow/require this kind of indentation:

    k_phoen_contact:
        redirect_url:   contact
        sender:         { address: 'no-reply@bar.baz' }
        receiver:       { address: foo@bar.baz }
