### PR TITLE
Symfony 2.8+ deprecates 'intention'

### DIFF
--- a/Form/Type/MessageType.php
+++ b/Form/Type/MessageType.php
@@ -34,9 +34,15 @@ class MessageType extends AbstractType
 
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults([
+        $defaults = array(
             'data_class' => 'KPhoen\ContactBundle\Model\Message',
-            'intention' => 'contact',
-        ]);
+        );
+        if ($resolver->isDefined('csrf_token_id')) {
+            $defaults['csrf_token_id'] = 'contact';
+        } else {
+            $defaults['intention'] = 'contact';
+        }
+
+        $resolver->setDefaults($defaults);
     }
 }


### PR DESCRIPTION
If the 'csrf_token_id' exists in options, use in preference to 'intention'